### PR TITLE
Improve documentation and naming across SwiftEvolution Viewer

### DIFF
--- a/EvolutionModel/Sources/Bookmark/Bookmark.swift
+++ b/EvolutionModel/Sources/Bookmark/Bookmark.swift
@@ -3,34 +3,56 @@ import SwiftData
 
 // MARK: - Bookmark
 
+/// Stores a user's bookmarked proposal for quick access.
+///
+/// The model keeps track of the associated `Proposal` and when the
+/// bookmark was last updated. Each bookmark is uniquely identified by the
+/// proposal's identifier.
 @Model
 public final class Bookmark {
     #Unique<Bookmark>([\.proposalID])
-    @Attribute(.unique) public private(set) var proposalID: String
-    @Attribute(.unique) public private(set) var proposal: Proposal
-    public var updateAt: Date
 
+    /// Unique identifier for the bookmarked proposal.
+    @Attribute(.unique) public private(set) var proposalID: String
+
+    /// The proposal associated with this bookmark.
+    @Attribute(.unique) public private(set) var proposal: Proposal
+
+    /// Timestamp indicating when the bookmark was last modified.
+    public var updatedAt: Date
+
+    /// Creates a new bookmark for the given proposal.
     init(proposal: Proposal) {
         self.proposal = proposal
         self.proposalID = proposal.proposalID
-        self.updateAt = .now
+        self.updatedAt = .now
     }
 }
 
 // MARK: - Snapshot
 
 public extension Bookmark {
+    /// Immutable representation of a ``Bookmark`` used for transferring data
+    /// across concurrency domains or persisting to disk.
     struct Snapshot: Hashable, Codable, Sendable {
+        /// Identifier of the stored model object, if available.
         public var persistentModelID: PersistentIdentifier?
-        public var proposalID: String
-        public var proposal: Proposal.Snapshot
-        public var updateAt: Date
 
+        /// Unique identifier for the bookmarked proposal.
+        public var proposalID: String
+
+        /// Lightweight snapshot of the associated proposal.
+        public var proposal: Proposal.Snapshot
+
+        /// Timestamp indicating the last update to the bookmark.
+        public var updatedAt: Date
+
+        /// Creates a snapshot from a managed ``Bookmark`` instance.
         init(object: Bookmark) {
             persistentModelID = object.persistentModelID
             proposalID = object.proposalID
             proposal = Proposal.Snapshot(object: object.proposal)
-            updateAt = object.updateAt
+            updatedAt = object.updatedAt
         }
     }
 }

--- a/EvolutionModel/Sources/Bookmark/BookmarkRepository.swift
+++ b/EvolutionModel/Sources/Bookmark/BookmarkRepository.swift
@@ -3,14 +3,22 @@ import SwiftData
 
 // MARK: - BookmarkRepository
 
+/// Provides data access for ``Bookmark`` objects stored in `SwiftData`.
+///
+/// All methods run on the actor's isolated model container to ensure safe
+/// access from concurrent contexts.
 @ModelActor
 public actor BookmarkRepository {
+    /// Returns all stored bookmarks as immutable snapshots.
     public func snapshots() -> [Bookmark.Snapshot] {
         let modelContext = ModelContext(modelContainer)
         let result = try? modelContext.fetch(FetchDescriptor<Bookmark>(predicate: .true))
         return result?.map(Bookmark.Snapshot.init) ?? []
     }
 
+    /// Loads a bookmark for the specified proposal identifier.
+    /// - Parameter proposalID: The identifier of the proposal to look up.
+    /// - Returns: A ``Bookmark/Snapshot`` if one exists, otherwise `nil`.
     public func load(proposalID: String) -> Bookmark.Snapshot? {
         let descriptor = FetchDescriptor(predicate: #Predicate<Bookmark> {
             $0.proposalID == proposalID
@@ -21,6 +29,10 @@ public actor BookmarkRepository {
         return object.flatMap(Bookmark.Snapshot.init(object:))
     }
 
+    /// Adds or removes a bookmark for the given proposal.
+    /// - Parameters:
+    ///   - proposal: Snapshot of the proposal to modify.
+    ///   - isBookmarked: Pass `true` to add a bookmark, or `false` to remove it.
     public func update(proposal: Proposal.Snapshot, isBookmarked: Bool) throws {
         if isBookmarked {
             try add(proposal: proposal)
@@ -29,6 +41,7 @@ public actor BookmarkRepository {
         }
     }
 
+    /// Inserts a new bookmark if one does not already exist.
     private func add(proposal: Proposal.Snapshot) throws {
         let context = ModelContext(modelContainer)
         let predicate = #Predicate<Proposal> { $0.proposalID == proposal.id }
@@ -41,6 +54,7 @@ public actor BookmarkRepository {
         }
     }
 
+    /// Deletes an existing bookmark for the given proposal.
     private func delete(proposal: Proposal.Snapshot) throws {
         let descriptor = FetchDescriptor(predicate: #Predicate<Bookmark> {
             $0.proposalID == proposal.id

--- a/EvolutionModel/Sources/Markdown/Markdown.swift
+++ b/EvolutionModel/Sources/Markdown/Markdown.swift
@@ -3,34 +3,56 @@ import SwiftData
 
 // MARK: - Markdown
 
+/// Represents the markdown content for a specific Swift Evolution proposal.
+///
+/// Each instance tracks the remote source URL, the proposal identifier, and
+/// optionally the fetched markdown text.
 @Model
 public final class Markdown {
     #Unique<Markdown>([\.url, \.proposalID])
+
     /// The remote URL pointing to the markdown file.
     @Attribute(.unique) public private(set) var url: URL
+
     /// The proposal identifier, such as "SE-0001".
     @Attribute(.unique) public private(set) var proposalID: String
-    /// Raw markdown text, populated after ``fetch()`` is called.
+
+    /// Raw markdown text, populated after the file is fetched.
     public var text: String?
 
+    /// Creates a new markdown record.
+    /// - Parameters:
+    ///   - url: Location of the markdown file.
+    ///   - proposalID: Identifier for the proposal this markdown belongs to.
+    ///   - text: Optional markdown string if already loaded.
     init(url: URL, proposalID: String, text: String? = nil) {
         self.url = url
         self.proposalID = proposalID
         self.text = text
     }
 
+    /// A snapshot representation of this model used for value semantics.
     public var snapshot: Snapshot {
         .init(object: self)
     }
 }
 
 public extension Markdown {
+    /// Immutable representation of a ``Markdown`` model.
     struct Snapshot: Hashable, Codable, Sendable {
+        /// Identifier of the underlying model object, if persisted.
         public var persistentModelID: PersistentIdentifier?
+
+        /// Remote location of the markdown file.
         public var url: URL
+
+        /// The related proposal's identifier.
         public var proposalID: String
+
+        /// Markdown text if it has been fetched.
         public var text: String?
 
+        /// Creates a snapshot from a ``Markdown`` instance.
         init(object: Markdown) {
             persistentModelID = object.persistentModelID
             url = object.url

--- a/EvolutionModel/Sources/Markdown/MarkdownRepository.swift
+++ b/EvolutionModel/Sources/Markdown/MarkdownRepository.swift
@@ -3,13 +3,18 @@ import SwiftData
 
 // MARK: - MarkdownRepository
 
+/// Handles network retrieval and persistence of proposal markdown files.
 @ModelActor
 public actor MarkdownRepository {
+    /// Downloads and stores the markdown for the given proposal.
+    /// - Parameter proposal: The proposal whose markdown should be fetched.
+    /// - Returns: A snapshot of the stored markdown content.
     @discardableResult
     public func fetch(proposal: Proposal.Snapshot) async throws -> Markdown.Snapshot {
         try await fetch(proposalID: proposal.id, url: MarkdownURL(link: proposal.link))
     }
 
+    /// Fetches markdown from the provided URL and persists it.
     private func fetch(proposalID: String, url: MarkdownURL) async throws -> Markdown.Snapshot {
         let url = url.rawValue
         let (data, _) = try await URLSession.shared.data(from: url)

--- a/EvolutionModel/Sources/Markdown/MarkdownURL.swift
+++ b/EvolutionModel/Sources/Markdown/MarkdownURL.swift
@@ -5,6 +5,8 @@ struct MarkdownURL: RawRepresentable, Codable, Hashable, Sendable {
     /// The fully qualified URL of the markdown document.
     let rawValue: URL
 
+    /// Directly wraps an existing markdown URL.
+    /// - Parameter rawValue: Fully qualified URL to a markdown document.
     init(rawValue: URL) {
         self.rawValue = rawValue
     }

--- a/EvolutionModel/Sources/Proposal/Proposal.swift
+++ b/EvolutionModel/Sources/Proposal/Proposal.swift
@@ -3,21 +3,31 @@ import SwiftData
 
 // MARK: - Proposal
 
+/// Represents a single Swift Evolution proposal.
+///
+/// Each proposal has an identifier, a link to its markdown content, a status,
+/// and a human-readable title. Proposals may also be bookmarked by the user.
 @Model
 public final class Proposal {
     #Unique<Proposal>([\.proposalID])
+
     /// The proposal identifier, such as "SE-0001".
     @Attribute(.unique) public var proposalID: String
+
     /// URL path to the proposal's markdown file on GitHub.
     public private(set) var link: String
+
     /// The current review status details.
     public private(set) var status: Status
+
     /// Human-readable proposal title.
     public private(set) var title: String
 
+    /// Reference to any bookmark associated with this proposal.
     @Relationship(deleteRule: .cascade, inverse: \Bookmark.proposal)
     public var bookmark: Bookmark?
 
+    /// Creates a managed proposal instance from a snapshot.
     public required init(snapshot: Snapshot) {
         self.proposalID = snapshot.id
         self.link = snapshot.link
@@ -25,6 +35,7 @@ public final class Proposal {
         self.title = snapshot.title.trimmingCharacters(in: .whitespaces)
     }
 
+    /// Updates the stored data using a more recent snapshot.
     @discardableResult
     public func update(with snapshot: Snapshot) -> Self {
         guard proposalID == snapshot.id else {
@@ -40,13 +51,24 @@ public final class Proposal {
 // MARK: - Snapshot
 
 extension Proposal {
+    /// Immutable view of a ``Proposal`` used for value semantics.
     public struct Snapshot: Hashable, Codable, Sendable {
+        /// Identifier of the persisted model, if any.
         public var persistentModelID: PersistentIdentifier?
+
+        /// Unique proposal identifier such as "SE-0001".
         public var id: String
+
+        /// Path to the proposal's markdown on GitHub.
         public var link: String
+
+        /// Current review status.
         public var status: Status
+
+        /// Proposal title.
         public var title: String
 
+        /// Creates a snapshot from a managed ``Proposal`` instance.
         public init(object: Proposal) {
             persistentModelID = object.persistentModelID
             id = object.proposalID
@@ -55,6 +77,7 @@ extension Proposal {
             title = object.title.trimmingCharacters(in: .whitespaces)
         }
 
+        /// Creates a snapshot with the provided values.
         public init(
             id: String,
             link: String,

--- a/EvolutionModel/Sources/Proposal/ProposalRepository.swift
+++ b/EvolutionModel/Sources/Proposal/ProposalRepository.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 // MARK: - ProposalRepository
 
+/// Retrieves and persists proposal metadata from the Swift Evolution feed.
 @ModelActor
 public actor ProposalRepository {
     /// Top-level structure of the `evolution.json` feed.
@@ -16,6 +17,8 @@ public actor ProposalRepository {
         URL(string: "https://download.swift.org/swift-evolution/v1/evolution.json")!
     }
 
+    /// Downloads the proposal feed and stores the results.
+    /// - Returns: An array of stored proposal snapshots.
     @discardableResult
     public func fetch() async throws -> [Proposal.Snapshot] {
         let (data, _) = try await URLSession.shared.data(from: url)
@@ -34,6 +37,8 @@ public actor ProposalRepository {
             .compactMap(Proposal.Snapshot.init)
     }
 
+    /// Finds a proposal by its identifier if it exists in storage.
+    /// - Parameter proposalID: The proposal identifier to search for.
     public func find(by proposalID: String) -> Proposal.Snapshot? {
         try? ModelContext(modelContainer)
             .fetch(.id(proposalID))
@@ -43,6 +48,7 @@ public actor ProposalRepository {
 }
 
 private extension FetchDescriptor<Proposal> {
+    /// Convenience helper for building a descriptor that looks up a proposal by ID.
     static func id(_ proposalID: String) -> Self {
         FetchDescriptor(predicate: #Predicate<Proposal> {
             $0.proposalID == proposalID

--- a/EvolutionModel/Sources/Proposal/Status.swift
+++ b/EvolutionModel/Sources/Proposal/Status.swift
@@ -3,6 +3,7 @@ import Foundation
 // MARK: - Status
 
 public extension Proposal {
+    /// Metadata describing the review lifecycle of a proposal.
     struct Status: Codable, Hashable, Sendable {
         /// Raw state string such as "activeReview" or "accepted".
         public var state: String
@@ -13,6 +14,7 @@ public extension Proposal {
         /// The start date for the proposal's review period.
         public var start: String?
 
+        /// Creates a new status description.
         public init(state: String, version: String? = nil, end: String? = nil, start: String? = nil) {
             self.state = state
             self.version = version
@@ -25,6 +27,7 @@ public extension Proposal {
 // MARK: - State
 
 public extension Proposal.Status {
+    /// Enumerates the standardized set of review states a proposal may be in.
     enum State: String, Codable, Hashable, CaseIterable, Sendable, Identifiable, CustomStringConvertible, Comparable {
         case accepted
         case activeReview
@@ -57,14 +60,17 @@ public extension Proposal.Status {
             }
         }
 
+        /// Initializes from a ``Proposal`` model if the state string matches a known case.
         public init?(proposal: Proposal) {
             self.init(rawValue: proposal.status.state)
         }
 
+        /// Initializes from a ``Proposal/Snapshot`` if the state string matches a known case.
         public init?(proposal: Proposal.Snapshot) {
             self.init(rawValue: proposal.status.state)
         }
 
+        /// Provides ordering for states based on their declaration order.
         public static func < (lhs: Self, rhs: Self) -> Bool {
             Index(state: lhs) < Index(state: rhs)
         }
@@ -72,6 +78,7 @@ public extension Proposal.Status {
 }
 
 public extension Proposal.Status.State {
+    /// Helper enum used to establish a sort order for ``Proposal.Status.State`` values.
     enum Index: Int, Comparable {
         case accepted
         case activeReview
@@ -81,6 +88,7 @@ public extension Proposal.Status.State {
         case returnedForRevision
         case withdrawn
 
+        /// Converts a state into its corresponding index value.
         public init(state: Proposal.Status.State) {
             self = unsafeBitCast(state, to: Index.self)
         }

--- a/EvolutionModule/Sources/Content/AppScene.swift
+++ b/EvolutionModule/Sources/Content/AppScene.swift
@@ -5,10 +5,12 @@ import SwiftUI
 
 // MARK: - AppScene
 
+/// Root scene for the application that wires up model containers and commands.
 @MainActor
 public struct AppScene<Content: View> {
     private var content: () -> Content
 
+    /// Creates the scene with the provided root content view.
     public init(@ViewBuilder content: @escaping () -> Content) {
         self.content = content
     }
@@ -17,6 +19,7 @@ public struct AppScene<Content: View> {
 // MARK: - Scene
 
 extension AppScene: Scene {
+    /// Body of the SwiftUI scene that hosts the app's content and commands.
     public var body: some Scene {
         WindowGroup {
             content()

--- a/EvolutionModule/Sources/Preview Content/PreviewTrait.swift
+++ b/EvolutionModule/Sources/Preview Content/PreviewTrait.swift
@@ -3,10 +3,12 @@ import EvolutionUI
 import SwiftData
 import SwiftUI
 
+/// Convenience trait for previews that require proposal data.
 extension PreviewTrait where T == Preview.ViewTraits {
     @MainActor public static var proposal: Self = .modifier(ProposalPreviewModifier())
 }
 
+/// Injects in-memory proposal data into SwiftUI previews.
 struct ProposalPreviewModifier: PreviewModifier {
     public static func makeSharedContext() throws -> ModelContainer {
         let container = try ModelContainer(

--- a/EvolutionModule/Sources/ProposalDetail/ContentDetailView.swift
+++ b/EvolutionModule/Sources/ProposalDetail/ContentDetailView.swift
@@ -3,20 +3,22 @@ import EvolutionUI
 import SwiftUI
 
 // MARK: -
-/// SplitView の Detail View
-///
-/// Detail View 側のナビゲーションスタックの管理を行う
+
+/// Detail side of the split view that manages its own navigation stack.
 struct ContentDetailView: View {
-    /// 詳細画面のNavigationPath
+    /// Navigation path for presenting nested proposal details.
     @State private var detailPath = NavigationPath()
-    /// 表示する値
+
+    /// The proposal to display.
     let proposal: Proposal.Snapshot
-    /// 水平サイズクラス
+
+    /// Horizontal size class of the surrounding environment.
     let horizontal: UserInterfaceSizeClass?
-    /// アクセントカラー（ ナビゲーションスタックにスタックされるごとに変更する ）
+
+    /// Accent color used for the navigation bar, updated for each pushed view.
     @Binding var accentColor: Color?
 
-    /// ModelContext
+    /// Model context used to load additional data.
     @Environment(\.modelContext) private var context
 
     var body: some View {
@@ -30,6 +32,7 @@ struct ContentDetailView: View {
         }
     }
 
+    /// Builds the actual detail view for a proposal.
     func detail(proposal: Proposal.Snapshot) -> some View {
         ProposalDetailView(path: $detailPath, proposal: proposal, modelContainer: context.container)
             .onChange(of: accentColor(proposal), initial: true) { _, color in
@@ -37,6 +40,7 @@ struct ContentDetailView: View {
             }
     }
 
+    /// Determines the accent color based on the proposal's status.
     func accentColor(_ proposal: Proposal.Snapshot) -> Color {
         Proposal.Status.State(proposal: proposal)?.color ?? .darkText
     }

--- a/EvolutionModule/Sources/ProposalDetail/ProposalDetailView+NavigationBar.swift
+++ b/EvolutionModule/Sources/ProposalDetail/ProposalDetailView+NavigationBar.swift
@@ -5,8 +5,9 @@ import SwiftUI
 
 extension ProposalDetailView {
     @MainActor
+    /// Toolbar content used within ``ProposalDetailView``.
     struct NavigationBar {
-        /// ViewModel
+        /// Backing view model for the proposal detail screen.
         @Bindable var viewModel: ProposalDetailViewModel
     }
 }
@@ -27,12 +28,12 @@ extension ProposalDetailView.NavigationBar {
     @ViewBuilder
     fileprivate func translateButton() -> some View {
         if !viewModel.translating {
-            Button("翻訳", systemImage: "character.bubble") {
+            Button("Translate", systemImage: "character.bubble") {
                 Task { try await viewModel.translate() }
             }
         } else {
             ZStack {
-                Button("翻訳", systemImage: "character.bubble") {}
+                Button("Translate", systemImage: "character.bubble") {}
                     .hidden()
                 ProgressView()
             }

--- a/EvolutionModule/Sources/ProposalDetail/ProposalDetailView.swift
+++ b/EvolutionModule/Sources/ProposalDetail/ProposalDetailView.swift
@@ -12,15 +12,19 @@ import SwiftUI
 
 @MainActor
 struct ProposalDetailView {
-    /// NavigationPath
+    /// Navigation path for pushing additional proposal details.
     @Binding var path: NavigationPath
-    /// ViewModel
+
+    /// Backing view model that loads markdown content.
     @State private var viewModel: ProposalDetailViewModel
-    /// マークダウン再取得トリガー
+
+    /// Trigger used to re-fetch markdown data.
     @State private var refresh: UUID?
-    /// コピーしたコードブロック
+
+    /// Recently copied code block to show in the HUD.
     @State private var copied: CopiedCode?
-    /// An action that opens a URL.
+
+    /// Action used to open URLs from markdown links.
     @Environment(\.openURL) private var openURL
 
     init(path: Binding<NavigationPath>, proposal: Proposal.Snapshot, modelContainer: ModelContainer) {
@@ -63,7 +67,7 @@ extension ProposalDetailView: View {
             NavigationBar(viewModel: viewModel)
         }
         .overlay {
-            ErrorView(error: viewModel.fetcherror) {
+            ErrorView(error: viewModel.fetchError) {
                 refresh = .init()
             }
         }
@@ -97,7 +101,7 @@ extension ProposalDetailView {
         }
     }
 
-    /// SFSafariViewController で Web コンテンツを表示
+    /// Presents web content in `SFSafariViewController` when available.
     @MainActor
     fileprivate func showSafariView(url: URL) {
         guard url.scheme?.contains(/^https?$/) == true else { return }

--- a/EvolutionModule/Sources/ProposalList/ProposalListCell.swift
+++ b/EvolutionModule/Sources/ProposalList/ProposalListCell.swift
@@ -5,14 +5,16 @@ import SwiftUI
 
 // MARK: - Cell
 
+/// Displays summary information for a proposal in the list view.
 struct ProposalListCell: View {
+    /// Proposal to be presented.
     let proposal: Proposal
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             let label = label
             HStack {
-                // ラベル
+                // Status label
                 Text(label.text)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
@@ -21,15 +23,15 @@ struct ProposalListCell: View {
                             .stroke()
                     }
                     .foregroundStyle(label.color)
-                // ブックマーク
+                // Bookmark indicator
                 Image(systemName: "bookmark.fill")
                     .foregroundStyle(label.color)
                     .opacity(proposal.bookmark != nil ? 1 : 0)
                     .animation(.default, value: proposal.bookmark)
             }
-            // 本文
+            // Title
             Text(title)
-                .lineLimit(nil)  // macOS でこの指定が必須
+                .lineLimit(nil)  // Required on macOS to allow multiline titles
         }
         #if os(macOS)
             .padding(.top, 8)
@@ -37,11 +39,13 @@ struct ProposalListCell: View {
         #endif
     }
 
+    /// Text and color pair representing the proposal's status.
     private var label: (text: String, color: Color) {
         let state = Proposal.Status.State(proposal: proposal)
         return (state.label, state.color)
     }
 
+    /// Combined identifier and title string.
     private var title: AttributedString {
         let id = AttributedString(
             proposal.proposalID,

--- a/EvolutionModule/Sources/ProposalList/ProposalListView.swift
+++ b/EvolutionModule/Sources/ProposalList/ProposalListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 // MARK: - ListView
 
+/// Displays a list of proposals and manages selection state.
 struct ProposalListView: View {
     @Environment(\.horizontalSizeClass) private var horizontal
     @Binding var selection: Proposal.Snapshot?
@@ -39,13 +40,14 @@ struct ProposalListView: View {
         .onAppear(perform: selectFirstItem)
     }
 
+    /// Selects the first proposal when running on larger displays.
     func selectFirstItem() {
         #if os(macOS)
             if selection == nil, let proposal = proposals.first {
                 selection = Markdown(proposal: .init(proposal))
             }
         #elseif os(iOS)
-            /// SplitView　が画面分割表示の場合に、初期表示を与える
+            // Provide an initial selection when the split view is displayed side-by-side.
             if horizontal == .regular, selection == nil, let proposal = proposals.first {
                 selection = .init(object: proposal)
             }

--- a/EvolutionUI/Sources/Extensions/AppStorage.swift
+++ b/EvolutionUI/Sources/Extensions/AppStorage.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 extension AppStorage where Value: RawRepresentable, Value.RawValue == String {
+    /// Convenience initializer that uses the type name as the storage key.
     public init(wrappedValue: Value, store: UserDefaults? = nil) {
         self.init(
             wrappedValue: wrappedValue,

--- a/EvolutionUI/Sources/Extensions/Binding.swift
+++ b/EvolutionUI/Sources/Extensions/Binding.swift
@@ -2,6 +2,8 @@ import EvolutionModel
 import SwiftUI
 
 extension Binding<Set<Proposal.Status.State>> {
+    /// Creates a binding that reflects whether the specified state is contained in the set.
+    /// - Parameter state: The proposal status to monitor.
     public func isOn(_ state: Proposal.Status.State) -> Binding<Bool> {
         Binding<Bool> {
             wrappedValue.contains(state)

--- a/EvolutionUI/Sources/Extensions/BlockStyle.swift
+++ b/EvolutionUI/Sources/Extensions/BlockStyle.swift
@@ -6,6 +6,7 @@ import SwiftUI
 
 @MainActor
 extension BlockStyle where Configuration == ListMarkerConfiguration {
+    /// A list marker that displays a small filled circle.
     public static var customCircle: Self {
         BlockStyle { _ in
             Circle()
@@ -14,6 +15,7 @@ extension BlockStyle where Configuration == ListMarkerConfiguration {
         }
     }
 
+    /// A list marker that renders ordered list numbers with monospaced digits.
     public static var customDecimal: Self {
         BlockStyle { configuration in
             Text("\(configuration.itemNumber).")

--- a/EvolutionUI/Sources/Extensions/Predicate.swift
+++ b/EvolutionUI/Sources/Extensions/Predicate.swift
@@ -3,6 +3,7 @@ import SwiftData
 import SwiftUI
 
 extension Query<Proposal, [Proposal]> {
+    /// Builds a query that filters proposals by status and bookmark state.
     public static func query(status: [Proposal.Status.State : Bool], isBookmarked: Bool) -> Query {
         Query(
             filter: .predicate(states: status, isBookmarked: isBookmarked),
@@ -14,6 +15,7 @@ extension Query<Proposal, [Proposal]> {
 }
 
 extension Predicate<Proposal> {
+    /// Predicate that matches proposals with the selected states and bookmark preference.
     public static func predicate(states: [Proposal.Status.State : Bool], isBookmarked: Bool) -> Predicate<Proposal> {
         let states = Set(states.filter { $0.value}.keys.map(\.rawValue))
         return #Predicate { proposal in

--- a/EvolutionUI/Sources/Extensions/ProposalStatusState.swift
+++ b/EvolutionUI/Sources/Extensions/ProposalStatusState.swift
@@ -2,6 +2,7 @@ import EvolutionModel
 import SwiftUI
 
 extension Proposal.Status.State {
+    /// Display color associated with each proposal status.
     public var color: Color {
         switch self {
         case .accepted:
@@ -21,6 +22,7 @@ extension Proposal.Status.State {
         }
     }
 
+    /// `UIColor` variant used for UIKit-based components.
     public var tintColor: UIColor {
         switch self {
         case .accepted:
@@ -42,6 +44,7 @@ extension Proposal.Status.State {
 }
 
 extension Proposal.Status.State? {
+    /// Human-readable string for the optional status.
     public var label: String {
         switch self {
         case .some(let state):
@@ -51,6 +54,7 @@ extension Proposal.Status.State? {
         }
     }
 
+    /// Fallback color when a status may be `nil`.
     public var color: Color {
         switch self {
         case .some(let state):
@@ -60,6 +64,7 @@ extension Proposal.Status.State? {
         }
     }
 
+    /// Fallback `UIColor` when a status may be `nil`.
     public var tintColor: UIColor {
         switch self {
         case .some(let state):
@@ -71,5 +76,6 @@ extension Proposal.Status.State? {
 }
 
 extension EnvironmentValues {
+    /// Environment value storing the set of currently selected proposal states.
     @Entry public var selectedStatus: Set<Proposal.Status.State> = .init(Proposal.Status.State.allCases)
 }

--- a/EvolutionUI/Sources/Extensions/SceneStorage.swift
+++ b/EvolutionUI/Sources/Extensions/SceneStorage.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 extension SceneStorage where Value: RawRepresentable, Value.RawValue == String {
+    /// Convenience initializer that uses the type name as the storage key.
     public init(wrappedValue: Value) {
         self.init(wrappedValue: wrappedValue, String(describing: Value.self))
     }

--- a/EvolutionUI/Sources/Extensions/ToolbarItemPlacement.swift
+++ b/EvolutionUI/Sources/Extensions/ToolbarItemPlacement.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension ToolbarItemPlacement {
-    /// Sprit View のプライマリ側
+    /// Toolbar placement used on the primary side of a split view.
     public static var content: Self {
         #if os(macOS)
             .automatic

--- a/EvolutionUI/Sources/Extensions/UIColor.swift
+++ b/EvolutionUI/Sources/Extensions/UIColor.swift
@@ -2,27 +2,32 @@ import SwiftUI
 
 // MARK: - Color
 #if os(macOS)
-    /// NSColor のエイリアス
+    /// Alias to `NSColor` for cross-platform code sharing.
 public typealias UIColor = NSColor
     extension UIColor {
+        /// Default tint color equivalent for macOS.
         static var tintColor: UIColor {
             controlTextColor.usingColorSpace(.extendedSRGB)!
         }
 
+        /// Background color matching the system window background.
         public static var systemBackground: UIColor {
             windowBackgroundColor.usingColorSpace(.extendedSRGB)!
         }
 
+        /// Secondary background color used for grouped content areas.
         public static var secondarySystemBackground: UIColor {
             windowBackgroundColor.usingColorSpace(.extendedSRGB)!
         }
 
+        /// Label color in the extended sRGB color space.
         public static var label: UIColor {
             labelColor.usingColorSpace(.extendedSRGB)!
         }
     }
 
     extension NSView {
+        /// Convenience property to bridge AppKit and UIKit background colors.
         public var backgroundColor: UIColor? {
             get {
                 (layer?.backgroundColor).flatMap(UIColor.init(cgColor:))

--- a/EvolutionUI/Sources/Extensions/UIViewRepresentable.swift
+++ b/EvolutionUI/Sources/Extensions/UIViewRepresentable.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 // MARK: - NSViewRepresentable
 #if os(macOS)
+    /// Cross-platform alias that mirrors `UIViewRepresentable` on macOS by wrapping `NSViewRepresentable`.
     public protocol UIViewRepresentable: NSViewRepresentable where NSViewType == ViewType {
         associatedtype ViewType: NSView
         @MainActor

--- a/EvolutionUI/Sources/Extensions/View.swift
+++ b/EvolutionUI/Sources/Extensions/View.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 #if os(macOS) || os(tvOS)
+    /// Minimal shim for `NavigationBarItem` APIs on platforms that lack them.
     public struct NavigationBarItem {
         public enum TitleDisplayMode {
             case automatic
@@ -12,6 +13,8 @@ import SwiftUI
 
 extension View {
     @inline(__always)
+    /// Cross-platform wrapper around `navigationBarTitleDisplayMode`.
+    /// - Parameter displayMode: Desired title display mode on iOS.
     public func iOSNavigationBarTitleDisplayMode(_ displayMode: NavigationBarItem.TitleDisplayMode)
         -> some View
     {

--- a/EvolutionUI/Sources/Views/ErrorView.swift
+++ b/EvolutionUI/Sources/Views/ErrorView.swift
@@ -26,7 +26,7 @@ public struct ErrorView: View {
                     Text(error.localizedDescription)
                 } actions: {
                     if let retry {
-                        Button("再試行", action: retry)
+                        Button("Retry", action: retry)
                     }
                 }
             }

--- a/EvolutionUI/Sources/Views/FilterCommands.swift
+++ b/EvolutionUI/Sources/Views/FilterCommands.swift
@@ -2,6 +2,7 @@ import EvolutionModel
 import SwiftUI
 
 @MainActor
+/// Menu commands for filtering proposals and toggling bookmarks.
 public struct FilterCommands {
     @StatusFilter private var filter
     @AppStorage("isBookmarked") private var isBookmarked: Bool = false
@@ -11,9 +12,9 @@ public struct FilterCommands {
 
 extension FilterCommands: Commands {
     public var body: some Commands {
-        CommandMenu("フィルタ") {
+        CommandMenu("Filter") {
             Divider()
-            Menu("レビューの状態") {
+            Menu("Review Status") {
                 ForEach(0..<3, id: \.self) { index in
                     let option = Proposal.Status.State.allCases[index]
                     Toggle(option.description, isOn: $filter(option))
@@ -23,14 +24,14 @@ extension FilterCommands: Commands {
 
                 Divider()
 
-                Button("すべて選択する") {
+                Button("Select All") {
                     let allCases = Proposal.Status.State.allCases
                     filter = .init(uniqueKeysWithValues: allCases.map { ($0, true) })
                 }
                 .disabled(filter.values.allSatisfy(\.self))
                 .keyboardShortcut("A", modifiers: [.command, .shift])
 
-                Button("すべて非選択にする") {
+                Button("Deselect All") {
                     filter = [:]
                 }
                 .disabled(filter.values.allSatisfy { !$0 })
@@ -38,7 +39,7 @@ extension FilterCommands: Commands {
             }
             Divider()
 
-            Toggle("ブックマークのみ表示する", isOn: $isBookmarked)
+            Toggle("Show Bookmarks Only", isOn: $isBookmarked)
                 .keyboardShortcut("B", modifiers: [.command, .shift])
         }
     }

--- a/EvolutionUI/Sources/Views/FlowLayout.swift
+++ b/EvolutionUI/Sources/Views/FlowLayout.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 // https://github.com/apple/sample-food-truck/blob/main/App/General/FlowLayout.swift
 // https://qiita.com/penguinsan_pg/items/aeab0dd86a9aa0ebdad9
+/// A flexible layout that arranges subviews in a flowing row-based grid.
 public struct FlowLayout: Layout {
     var alignment: Alignment = .center
     var spacing: CGFloat?
@@ -40,10 +41,12 @@ public struct FlowLayout: Layout {
         }
     }
 
+    /// Pre-computed layout information for arranging subviews.
     struct FlowResult {
         var bounds = CGSize.zero
         var rows = [Row]()
 
+        /// A single row within the flow layout.
         struct Row {
             var range: Range<Int>
             var xOffsets: [Double]

--- a/EvolutionUI/Sources/Views/MarkdownStyleModifier.swift
+++ b/EvolutionUI/Sources/Views/MarkdownStyleModifier.swift
@@ -2,9 +2,9 @@ import MarkdownUI
 import Splash
 import SwiftUI
 
-/// マークダウンの設定
+/// Configures markdown styling for proposal content.
 public struct MarkdownStyleModifier: ViewModifier {
-    /// ColorScheme
+    /// Current color scheme of the environment.
     @Environment(\.colorScheme) private var colorScheme
 
     public init() {}

--- a/EvolutionUI/Sources/Views/MyCodeBlock.swift
+++ b/EvolutionUI/Sources/Views/MyCodeBlock.swift
@@ -2,9 +2,9 @@ import MarkdownUI
 import Splash
 import SwiftUI
 
-/// コードブロック
+/// Displays a stylized code block with copy-to-clipboard support.
 public struct MyCodeBlock: View {
-    /// ColorScheme
+    /// Current color scheme used to select the syntax highlighting theme.
     @Environment(\.colorScheme) private var colorScheme
     @State private var copied: CopiedCode?
 
@@ -83,6 +83,7 @@ public struct MyCodeBlock: View {
     }
 }
 
+/// Represents a block of code that was copied to the clipboard.
 public struct CopiedCode: PreferenceKey, Hashable, Identifiable {
     public var id = UUID()
     public var code: String

--- a/EvolutionUI/Sources/Views/ProposalDetailRow.swift
+++ b/EvolutionUI/Sources/Views/ProposalDetailRow.swift
@@ -36,13 +36,13 @@ extension [ProposalDetailRow] {
         }
     }
 
-    /// Markdownのヘッダー行からHTMLのidスラッグを作る
+    /// Generates an HTML `id` slug from a Markdown heading line.
     /// - Parameters:
-    ///   - line: 例: "### `~Copyable` as logical negation"
-    ///   - includeHash: 先頭に `#` を付ける（デフォルト true）
-    /// - Returns: 例: "#copyable-as-logical-negation"
+    ///   - line: Example: "### `~Copyable` as logical negation"
+    ///   - includeHash: Whether to prefix the slug with `#` (default is `true`).
+    /// - Returns: Example: "#copyable-as-logical-negation"
     private nonisolated static func htmlID(fromMarkdownHeader line: String, includeHash: Bool = true) -> String {
-        // 1) 先頭の見出しマーカーを除去（0〜3個の空白 + #1〜6 + 空白）
+        // 1) Remove leading heading markers (0-3 spaces + 1-6 # characters + space)
         let headerPattern = #"^\s{0,3}#{1,6}\s+"#
         let textStart = line.replacingOccurrences(
             of: headerPattern,
@@ -50,13 +50,13 @@ extension [ProposalDetailRow] {
             options: .regularExpression
         )
 
-        // 2) バッククォートとかっこを除去（中身は残す）
+        // 2) Remove backticks and parentheses but keep contents
         var s = textStart.replacingOccurrences(of: "`", with: "")
             .replacingOccurrences(of: "(", with: "")
             .replacingOccurrences(of: ")", with: "")
 
-        // 3) Unicode正規化（ローマ字化→ダイアクリティカル除去）
-        //    例: "Café" -> "Cafe", 日本語は toLatin でローマ字化される場合あり
+        // 3) Unicode normalization (Romanization followed by diacritic removal)
+        //    e.g., "Café" -> "Cafe"; Japanese may be romanized with `toLatin`
         if let latin = s.applyingTransform(.toLatin, reverse: false) {
             s = latin
         }
@@ -65,21 +65,21 @@ extension [ProposalDetailRow] {
             locale: .current
         )
 
-        // 4) 小文字化
+        // 4) Lowercase all characters
         s = s.lowercased()
 
-        // 5) 許可しない文字をハイフンに置換（英数以外はまとめて-）
-        //    連続する非英数字は1つのハイフンに圧縮
+        // 5) Replace disallowed characters with a hyphen
+        //    Consecutive non-alphanumerics are collapsed into a single hyphen
         s = s.replacingOccurrences(
             of: #"[^a-z0-9]+"#,
             with: "-",
             options: .regularExpression
         )
 
-        // 6) 前後のハイフンをトリム
+        // 6) Trim leading and trailing hyphens
         s = s.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
 
-        // 7) 空ならフォールバック
+        // 7) Fallback if the result is empty
         if s.isEmpty { s = "section" }
 
         return includeHash ? "#\(s)" : s

--- a/EvolutionUI/Sources/Views/ProposalStatusPicker.swift
+++ b/EvolutionUI/Sources/Views/ProposalStatusPicker.swift
@@ -2,6 +2,7 @@ import EvolutionModel
 import Observation
 import SwiftUI
 
+/// Toolbar button that allows users to filter proposals by status.
 public struct ProposalStatusPicker: View {
     @State private var showPopover = false
     @StatusFilter private var filter
@@ -52,6 +53,7 @@ public struct ProposalStatusPicker: View {
         }
     }
 
+    /// Icon name reflecting whether filters are active.
     var iconName: String {
         filter.values.allSatisfy(\.self)
             ? "line.3.horizontal.decrease.circle"

--- a/EvolutionUI/Sources/Views/SettingsView.swift
+++ b/EvolutionUI/Sources/Views/SettingsView.swift
@@ -12,14 +12,14 @@ public struct SettingsView: View {
         TabView {
             AcknowledgementsView()
                 .tabItem {
-                    Label("謝辞", systemImage: "hands.clap.fill")
+                    Label("Acknowledgements", systemImage: "hands.clap.fill")
                 }
                 .tag(Tabs.general)
         }
     }
 }
 
-/// 謝辞
+/// Displays acknowledgements for third-party libraries.
 struct AcknowledgementsView: View {
     @State var selection = Acknowledgement.allItems.first
     @State var items = Acknowledgement.allItems

--- a/EvolutionUI/Sources/Views/SplashCodeSyntaxHighlighter.swift
+++ b/EvolutionUI/Sources/Views/SplashCodeSyntaxHighlighter.swift
@@ -3,11 +3,13 @@ import Splash
 import SwiftUI
 
 public extension CodeSyntaxHighlighter where Self == SplashCodeSyntaxHighlighter {
+    /// Creates a Splash-based syntax highlighter with the given theme.
     static func splash(theme: Splash.Theme) -> Self {
         Self.init(theme: theme)
     }
 }
 
+/// Syntax highlighter leveraging the Splash library.
 public struct SplashCodeSyntaxHighlighter: CodeSyntaxHighlighter {
     private let highlighter: SyntaxHighlighter<Format>
 

--- a/EvolutionUI/Sources/Views/StatusFilter.swift
+++ b/EvolutionUI/Sources/Views/StatusFilter.swift
@@ -2,6 +2,7 @@ import EvolutionModel
 import SwiftUI
 
 @propertyWrapper
+/// Stores a mapping of proposal statuses to inclusion flags using `AppStorage`.
 public struct StatusFilter: DynamicProperty {
     @AppStorage("accepted")
     private var accepted = true
@@ -43,6 +44,7 @@ public struct StatusFilter: DynamicProperty {
         }
     }
 
+    /// Provides bindings to individual status flags.
     public var projectedValue: (_ status: Proposal.Status.State) -> (Binding<Bool>) {
         return { status in
             switch status {


### PR DESCRIPTION
## Summary
- add descriptive documentation across model, module, and UI layers
- correct variable names and strings for clearer English
- clarify proposal bookmarking and filtering behaviors

## Testing
- `swift test` *(fails: package 'evolutionmodel' is using Swift tools version 6.2.0 but the installed version is 6.1.0)*
- `swift test` *(fails: package 'evolutionmodule' is using Swift tools version 6.2.0 but the installed version is 6.1.0)*
- `swift test` *(fails: package 'evolutionui' is using Swift tools version 6.2.0 but the installed version is 6.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b15bcba4a8832c94ba2462237ee93c